### PR TITLE
Add item drop & pickup forwards

### DIFF
--- a/addons/sourcemod/scripting/entwatch/module_forwards.inc
+++ b/addons/sourcemod/scripting/entwatch/module_forwards.inc
@@ -3,7 +3,9 @@
 Handle	g_hOnBanForward,
 		g_hOnUnbanForward,
 		g_hOnHLPrivWeaponForward,
-		g_hOnHLPrivPlayerForward;
+		g_hOnHLPrivPlayerForward,
+		g_hOnItemPickup,
+		g_hOnItemDrop;
 
 stock void EWM_Forwards_OnPluginStart()
 {
@@ -11,4 +13,6 @@ stock void EWM_Forwards_OnPluginStart()
 	g_hOnUnbanForward = CreateGlobalForward("EntWatch_OnClientUnbanned", ET_Ignore, Param_Cell, Param_Cell, Param_String);
 	g_hOnHLPrivWeaponForward = CreateGlobalForward("EntWatch_OnHLWeaponReady", ET_Ignore);
 	g_hOnHLPrivPlayerForward = CreateGlobalForward("EntWatch_OnHLPlayerReady", ET_Ignore);
+	g_hOnItemPickup = CreateGlobalForward("EntWatch_OnItemPickup", ET_Ignore, Param_Cell, Param_Cell);
+	g_hOnItemDrop = CreateGlobalForward("EntWatch_OnItemDrop", ET_Ignore, Param_Cell, Param_Cell);
 }

--- a/addons/sourcemod/scripting/entwatch_csgo_dz.sp
+++ b/addons/sourcemod/scripting/entwatch_csgo_dz.sp
@@ -373,6 +373,12 @@ stock void EWM_Drop_Forward(Handle hEvent)
 					}
 				}
 			}
+			
+			// Fire weapon drop forward
+			Call_StartForward(g_hOnItemDrop);
+			Call_PushCell(iClient);
+			Call_PushCell(ItemTest.WeaponID);
+			Call_Finish();
 		}
 	}
 }
@@ -1089,12 +1095,12 @@ public Action Timer_OnTriggerSpawned(Handle timer, int iEntity)
 public Action OnTrigger(int iEntity, int iClient)
 {
 	#if defined EW_MODULE_EBAN
-    if (IsValidClient(iClient) && IsClientConnected(iClient)) if (g_bGlobalBlock || g_EbanClients[iClient].Banned) return Plugin_Handled;
+	if (IsValidClient(iClient) && IsClientConnected(iClient)) if (g_bGlobalBlock || g_EbanClients[iClient].Banned) return Plugin_Handled;
 	#else
 	if (IsValidClient(iClient) && IsClientConnected(iClient) && g_bGlobalBlock) return Plugin_Handled;
 	#endif
 	
-    return Plugin_Continue;
+	return Plugin_Continue;
 }
 
 //-------------------------------------------------------
@@ -1645,6 +1651,12 @@ public void OnWeaponDrop(int iClient, int iWeapon)
 				break;
 			}
 		}
+
+		// Fire item drop forward
+		Call_StartForward(g_hOnItemDrop);
+		Call_PushCell(iClient);
+		Call_PushCell(iWeapon);
+		Call_Finish();
 	}
 }
 
@@ -1721,6 +1733,12 @@ public void OnWeaponEquip(int iClient, int iWeapon)
 		#if defined EW_MODULE_PHYSBOX
 		EWM_Physbox_Pickedup(iClient, iWeapon);
 		#endif
+
+		// Fire item pickup forward
+		Call_StartForward(g_hOnItemPickup);
+		Call_PushCell(iClient);
+		Call_PushCell(iWeapon);
+		Call_Finish();
 	}
 }
 

--- a/addons/sourcemod/scripting/include/EntWatch.inc
+++ b/addons/sourcemod/scripting/include/EntWatch.inc
@@ -240,6 +240,24 @@ forward void EntWatch_OnHLWeaponReady();
  */
 forward void EntWatch_OnHLPlayerReady();
 
+/**
+ * Called when a client picks up an item
+ * 
+ * @param client		Client index that picked up an item
+ * @param weapon		Entity index of the picked up item
+ * @return None
+ */
+forward void EntWatch_OnItemPickup(int client, int weapon);
+
+/**
+ * Called when a client drops an item
+ * 
+ * @param client		Client index that dropped the item
+ * @param weapon		Entity index of the dropped item
+ * @return None
+ */
+forward void EntWatch_OnItemDrop(int client, int weapon);
+
 public SharedPlugin __pl_EntWatch =
 {
 	name = "EntWatch",


### PR DESCRIPTION
Added item drop & item pickup forwards for other plugins to interact with EntWatch. Useful for plugins that do things exclusively for item users like hide plugin for example.