### PR TITLE
feat: support legacy configs

### DIFF
--- a/addons/sourcemod/scripting/entwatch/function.inc
+++ b/addons/sourcemod/scripting/entwatch/function.inc
@@ -10,6 +10,7 @@ enum struct class_ItemConfig
 	char		Color[16];
 	char		ButtonClass[32];
 	char		FilterName[32];
+	bool		HasFilterName;
 	bool		BlockPickup;
 	bool		AllowTransfer;
 	bool		ForceDrop;
@@ -44,6 +45,7 @@ enum struct class_ItemList
 	char		Color[16];			// String:	Color for visual highlighting in chat and highlight color definitions
 	char		ButtonClass[32];	// String:	Entity class name to activate item actions (func_button/func_door/game_ui)
 	char		FilterName[32];		// String:	Targetname of the player that can activate the item (filter_activator_name)
+	bool		HasFilterName;		// Bool:	Ignore filtername (Support for old configs)
 	bool		BlockPickup;		// Bool:	Disable item selection
 	bool		AllowTransfer;		// Bool:	Allow transferring an item to another player
 	bool		ForceDrop;			// Bool:	Necessary for proper handling of the drop function

--- a/addons/sourcemod/scripting/entwatch_dz.sp
+++ b/addons/sourcemod/scripting/entwatch_dz.sp
@@ -653,7 +653,13 @@ stock void LoadConfig()
 			
 			KvGetString(hKeyValues, "filtername", sBuffer_temp, sizeof(sBuffer_temp), "");
 			FormatEx(NewItem.FilterName, sizeof(NewItem.FilterName), "%s", sBuffer_temp);
-			
+
+			KvGetString(hKeyValues, "hasfiltername", sBuffer_temp, sizeof(sBuffer_temp), "notfound");
+			if (StrEqual(sBuffer_temp, "notfound", true))
+				NewItem.HasFilterName = true;
+			else
+				NewItem.HasFilterName = StrEqual(sBuffer_temp, "true", true);
+
 			KvGetString(hKeyValues, "blockpickup", sBuffer_temp, sizeof(sBuffer_temp), "false");
 			NewItem.BlockPickup = StrEqual(sBuffer_temp, "true", false);
 			
@@ -849,6 +855,7 @@ public bool RegisterItem(class_ItemConfig ItemConfig, int iEntity, int iHammerID
 		FormatEx(NewItem.Color,			sizeof(NewItem.Color),			"%s",	ItemConfig.Color);
 		FormatEx(NewItem.ButtonClass,	sizeof(NewItem.ButtonClass),	"%s",	ItemConfig.ButtonClass);
 		FormatEx(NewItem.FilterName,	sizeof(NewItem.FilterName),		"%s",	ItemConfig.FilterName);
+		NewItem.HasFilterName = ItemConfig.HasFilterName;
 		NewItem.BlockPickup = ItemConfig.BlockPickup;
 		NewItem.AllowTransfer = ItemConfig.AllowTransfer;
 		NewItem.ForceDrop = ItemConfig.ForceDrop;
@@ -1214,7 +1221,7 @@ public Action OnButtonUse(int iButton, int iActivator, int iCaller, UseType uTyp
 						
 						
 						if(ItemTest.OwnerID != iActivator && ItemTest.OwnerID != iCaller) return Plugin_Handled;
-							else if(!(StrEqual(ItemTest.FilterName,""))) DispatchKeyValue(iActivator, "targetname", ItemTest.FilterName);
+							else if(ItemTest.HasFilterName && !(StrEqual(ItemTest.FilterName,""))) DispatchKeyValue(iActivator, "targetname", ItemTest.FilterName);
 						
 						UpdateTime();
 						if(ItemTest.CheckDelay() > 0.0) return Plugin_Handled;
@@ -1535,7 +1542,7 @@ public Action Event_GameUI_RightClick(const char[] sOutput, int iCaller, int iAc
 				if(iAbility == 1 && ItemTest.ButtonID2 == INVALID_ENT_REFERENCE) iAbility = 0;
 				if(iAbility > -1)
 				{
-					if(!(StrEqual(ItemTest.FilterName,""))) DispatchKeyValue(iActivator, "targetname", ItemTest.FilterName);
+					if(ItemTest.HasFilterName && !(StrEqual(ItemTest.FilterName,""))) DispatchKeyValue(iActivator, "targetname", ItemTest.FilterName);
 					UpdateTime();
 					if(ItemTest.CheckDelay() > 0.0) continue;
 					if(iAbility != 2)


### PR DESCRIPTION
Support legacy configs that had `hasfiltername` as you can see here:
- https://github.com/NiDE-gg/ZE-Configs/blob/master/cstrike/cfg/sourcemod/entwatch/maps/ZE_FFVII_Mako_Reactor_V6_B08.cfg