### PR TITLE
fix(dz79): buttonid registration

### DIFF
--- a/addons/sourcemod/scripting/entwatch/function.inc
+++ b/addons/sourcemod/scripting/entwatch/function.inc
@@ -72,7 +72,6 @@ enum struct class_ItemList
 	int			Team;				// Integer:	Which team owns the item (-1 - No Team, 1 - Spec, 2 - T, 3 - CT)
 	bool		LockButton;			// Bool:	Item cannot be used
 	float		WaitTime;			// Float:	Timestamp when the button is rolled back
-	bool 		IsRegisterButton;	// Bool:	Is the button registered in the array
 	
 	// Parameters for the entity activating the second ability
 	char		ButtonClass2[32];

--- a/addons/sourcemod/scripting/include/EntWatch.inc
+++ b/addons/sourcemod/scripting/include/EntWatch.inc
@@ -4,7 +4,7 @@
 #define _EntWatch_include
 
 #define EW_V_MAJOR   "3"
-#define EW_V_MINOR   "78"
+#define EW_V_MINOR   "79"
 
 #define EW_VERSION   EW_V_MAJOR...".DZ."...EW_V_MINOR
 


### PR DESCRIPTION
@notkoen reported this:
`Entwatch configs with buttonid specified is not properly being tracked. Both ze_castlevania_v1_3 and ze_castlevania_nes_v1_7_1 have specified "buttonid" for the knife items, but EntWatch is failing to detect when those buttons are being pressed.`

## Root Cause

The issue was in the `RegisterButton` function.
The function only registered buttons that had a parent-child relationship with the weapon entity, but when a specific `buttonid` is provided in the config, the button should be registered regardless of this relationship.

Additionally, the `IsRegisterButton` flag was preventing multiple buttons from being registered for the same item, which is problematic for items that have both primary and secondary buttons.

## Solution

### 1. Modified Button Registration Logic

The `RegisterButton` function now checks for two conditions:
- **Primary**: If the button's HammerID matches a configured `buttonid` or `buttonid2`
- **Fallback**: If no specific buttonid is configured, fall back to the original parent-child relationship check

### 2. Fixed Multiple Button Registration

Replaced the `IsRegisterButton` flag check with a more specific check that prevents duplicate registrations of the same button entity while allowing multiple different buttons for the same item.